### PR TITLE
fix: add Github Actions

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,34 @@
+name: Github Pages
+on:
+  push:
+    branches: [main]
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set output vars
+        id: vars
+        run: echo ::set-output name=BRANCH_SHORT_REF::${GITHUB_REF#refs/*/}
+      - name: Checkout
+        uses: actions/checkout@v2.3.1 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+      - name: Build
+        run: |
+          npm install
+          npm run build
+        env:
+          PREFIX_PATHS: true # equivalent to --prefix-paths flag for 'gatsby build'
+          PATH_PREFIX: ${{ github.event.repository.name }}
+          GATSBY_LAUNCH_SRC: ${{ secrets.GATSBY_LAUNCH_SRC }}
+          GATSBY_LAUNCH_SRC_INCLUDE_IN_DEVELOPMENT: ${{ secrets.GATSBY_LAUNCH_SRC_INCLUDE_IN_DEVELOPMENT }}
+          REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_OWNER: ${{ github.event.repository.owner.login }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          REPO_BRANCH: ${{ steps.vars.outputs.BRANCH_SHORT_REF }}
+      - name: Deploy to GH Pages
+        uses: JamesIves/github-pages-deploy-action@3.5.7
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: public # The folder the action should deploy.

--- a/.github/workflows/pr-approved.yml
+++ b/.github/workflows/pr-approved.yml
@@ -1,0 +1,201 @@
+name: pr-approved
+
+on:
+  pull_request_review:
+    types: [submitted]
+    branches: ['main']
+
+jobs:
+  set-state:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_approved: ${{ github.event.review.state == 'approved' }}
+      deploy_prod: ${{ contains(github.event.pull_request.labels.*.name, 'deploy') }}
+      deploy_dev: ${{ contains(github.event.pull_request.labels.*.name, 'deploy:dev')}}
+      branch_short_ref: ${{ github.event.pull_request.head.ref }}
+    steps:
+      - name: check fork
+        # The GH token used when a PR is a fork is read-only, for security reasons
+        # (so the forked PR can't steal secrets, for example)
+        # This prevents us from adding comments, etc. So the requirements are:
+        #     1. the PR must be from a branch in the same repo
+        #     2. consequently, the PR creator must be a Contributor to the repo
+        # This ensures trust, and the GH token will thus be read-write.
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "::error::PRs from forks are not supported (Github security issue).%0APRs should be from a branch in the same repo, created by a Contributor."
+          exit 1
+      - name: check PATH_PREFIX (string) is set
+        if: env.PATH_PREFIX == null
+        run: |
+          echo "::error::Please set the Gatsby PATH_PREFIX (string) value in Github Secrets"
+          exit 1
+        env:
+          PATH_PREFIX: ${{ secrets.PATH_PREFIX }}
+
+  echo-state:
+    needs: [set-state]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "PR Review State - ${{ github.event.review.state }}"
+      - run: echo "PR Labels - ${{ join(github.event.pull_request.labels.*.name, ',') }}"
+      - run: echo "PR Approved - ${{ needs.set-state.outputs.pr_approved }}"
+      - run: echo "Deploy - ${{ needs.set-state.outputs.deploy_prod }}"
+      - run: echo "Deploy Dev - ${{ needs.set-state.outputs.deploy_dev }}"
+      - run: echo "Branch Short Ref - ${{ needs.set-state.outputs.branch_short_ref }}"
+
+  pre-build-dev:
+    needs: [set-state]
+    runs-on: ubuntu-latest
+    if: needs.set-state.outputs.pr_approved == 'true' && needs.set-state.outputs.deploy_dev == 'true'
+    steps:
+      - name: check dev azure connection string
+        if: env.AZURE_DEV_CONNECTION_STRING == null
+        run: |
+          echo "::error::Please set the Azure Blob Storage connection string as AZURE_DEV_CONNECTION_STRING in Github Secrets"
+          exit 1
+        env:
+          AZURE_DEV_CONNECTION_STRING: ${{ secrets.AZURE_DEV_CONNECTION_STRING }}
+      - name: 'Comment PR'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '⏳ Start build && deploy to dev'
+            })
+
+  build-dev:
+    defaults:
+      run:
+        shell: bash
+    needs: [set-state, pre-build-dev]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.1 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+      - name: Build
+        run: |
+          npm install
+          npm run build
+          if [ "$PATH_PREFIX" = "%%none%%" ]; then
+            # rename since the folder doesn't exist
+            mv $GITHUB_WORKSPACE/public $GITHUB_WORKSPACE/dist
+          else
+            mkdir -p $GITHUB_WORKSPACE/dist/$PATH_PREFIX
+            cp -a $GITHUB_WORKSPACE/public/. $GITHUB_WORKSPACE/dist/$PATH_PREFIX
+          fi
+        env:
+          PREFIX_PATHS: true # equivalent to --prefix-paths flag for 'gatsby build'
+          PATH_PREFIX: ${{ secrets.PATH_PREFIX }}
+          GATSBY_LAUNCH_SRC: ${{ secrets.GATSBY_LAUNCH_SRC }}
+          GATSBY_LAUNCH_SRC_INCLUDE_IN_DEVELOPMENT: ${{ secrets.GATSBY_LAUNCH_SRC_INCLUDE_IN_DEVELOPMENT }}
+          REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_OWNER: ${{ github.event.repository.owner.login }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          REPO_BRANCH: ${{ needs.set-state.outputs.branch_short_ref }}
+      - name: Deploy
+        uses: tibor19/static-website-deploy@v1
+        with:
+          enabled-static-website: 'true'
+          folder: 'dist'
+          connection-string: ${{ secrets.AZURE_DEV_CONNECTION_STRING }}
+
+  post-build-dev:
+    needs: [build-dev]
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Comment PR'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '🏄🏽‍♂️ Deployed to dev'
+            })
+
+  pre-build-production:
+    needs: [set-state]
+    runs-on: ubuntu-latest
+    if: needs.set-state.outputs.pr_approved == 'true' && needs.set-state.outputs.deploy_prod == 'true'
+    steps:
+      - name: check prod azure connection string
+        if: env.AZURE_PROD_CONNECTION_STRING == null
+        run: |
+          echo "::error::Please set the Azure Blob Storage connection string as AZURE_PROD_CONNECTION_STRING in Github Secrets"
+          exit 1
+        env:
+          AZURE_PROD_CONNECTION_STRING: ${{ secrets.AZURE_PROD_CONNECTION_STRING }}
+      - name: 'Comment PR'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '⏳ Start build && deploy to production'
+            })
+
+  build-production:
+    defaults:
+      run:
+        shell: bash
+    needs: [set-state, pre-build-production]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+      - name: Build
+        run: |
+          npm install
+          npm run build
+          if [ "$PATH_PREFIX" = "%%none%%" ]; then
+            # rename since the folder doesn't exist
+            mv $GITHUB_WORKSPACE/public $GITHUB_WORKSPACE/dist
+          else
+            mkdir -p $GITHUB_WORKSPACE/dist/$PATH_PREFIX
+            cp -a $GITHUB_WORKSPACE/public/. $GITHUB_WORKSPACE/dist/$PATH_PREFIX
+          fi
+        env:
+          PREFIX_PATHS: true # equivalent to --prefix-paths flag for 'gatsby build'
+          PATH_PREFIX: ${{ secrets.PATH_PREFIX }}
+          GATSBY_LAUNCH_SRC: ${{ secrets.GATSBY_LAUNCH_SRC }}
+          GATSBY_LAUNCH_SRC_INCLUDE_IN_DEVELOPMENT: ${{ secrets.GATSBY_LAUNCH_SRC_INCLUDE_IN_DEVELOPMENT }}
+          REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_OWNER: ${{ github.event.repository.owner.login }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          REPO_BRANCH: ${{ needs.set-state.outputs.branch_short_ref }}
+      - name: Deploy
+        uses: tibor19/static-website-deploy@v1
+        with:
+          enabled-static-website: 'true'
+          folder: 'dist'
+          connection-string: ${{ secrets.AZURE_PROD_CONNECTION_STRING }}
+
+  post-build-production:
+    needs: [build-production]
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Comment PR'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '🏄🏽‍♂️ Deployed to production'
+            })            


### PR DESCRIPTION
This PR adds the GH Actions needed to deploy to:
1. Github Pages on every commit
2. Azure Static Web Sites on a PR approval according to the deployment requirements 

Also, I will need admin access to this repo to add the Github Secrets needed. Please add the team `dev_site_admins` to this repo.