### PR TITLE
Fix relative paths for integrate docs

### DIFF
--- a/src/pages/integrate/guides/index.md
+++ b/src/pages/integrate/guides/index.md
@@ -2,13 +2,13 @@
 
 ### Guides
 
-[Working with Library elements](./working-with-elements/)
+[Working with Library elements](/integrate/guides/working-with-elements/)
 
 Learn all about supported libary elements, how to fetch element data, and how to create new elements in a library.
 
 <DiscoverBlock slots="link, text"/>
 
-[Configuring webhooks for Libraries Events](./configuring-events-webhooks/)
+[Configuring webhooks for Libraries Events](/integrate/guides/configuring-events-webhooks/)
 
 Listen for updates in Libraries and get notified when users make changes.
 

--- a/src/pages/integrate/setup/index.md
+++ b/src/pages/integrate/setup/index.md
@@ -2,13 +2,13 @@
 
 ### Setup
 
-[How to get your developer credentials](developer-credentials/)
+[How to get your developer credentials](/integrate/setup/developer-credentials/)
 
 Before you get started, you'll need a Client ID and Secret. We'll show you how to get them on the Adobe Developer Console.
 
 <DiscoverBlock slots="link, text"/>
 
-[How to get access tokens with OAuth](oauth/)
+[How to get access tokens with OAuth](/integrate/setup/oauth/)
 
 See where to learn more about Adobe OAuth 2.0 and try our OAuth 2.0 Playground for a quicker start.
 

--- a/src/pages/integrate/tutorials/index.md
+++ b/src/pages/integrate/tutorials/index.md
@@ -2,12 +2,12 @@
 
 ### Tutorials
 
-[Quick Start with cURL](quick-start-curl/)
+[Quick Start with cURL](/integrate/tutorials/quick-start-curl/)
 
 Make your first API call via the cURL command-line tool.
 
 <DiscoverBlock slots="link, text"/>
 
-[Quick Start with Node.js](quick-start-nodejs/)
+[Quick Start with Node.js](/integrate/tutorials/quick-start-nodejs/)
 
 Make your first API call from a Node.js script.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Following the links to the Guides, Setup, and Tutorials sections results in a 404. This change fixes the relative links for those sections that are not working.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/AdobeDocs/cc-libraries-api/issues/49

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
